### PR TITLE
fix: update namespaces for RNTuple stable API

### DIFF
--- a/fairroot/base/sink/FairRNTupleSink.cxx
+++ b/fairroot/base/sink/FairRNTupleSink.cxx
@@ -40,9 +40,9 @@ R__LOAD_LIBRARY(ROOTNTuple)
 #include <fairlogger/Logger.h>
 #include <string>
 
-using REntry = ROOT::Experimental::REntry;
-using RNTupleWriter = ROOT::Experimental::RNTupleWriter;
-using RNTupleModel = ROOT::Experimental::RNTupleModel;
+using REntry = ROOT::REntry;
+using RNTupleWriter = ROOT::RNTupleWriter;
+using RNTupleModel = ROOT::RNTupleModel;
 
 FairRNTupleSink::FairRNTupleSink(const TString* RootFileName, const char* Title)
     : FairSink()

--- a/fairroot/base/sink/FairRNTupleSink.h
+++ b/fairroot/base/sink/FairRNTupleSink.h
@@ -32,10 +32,10 @@ R__LOAD_LIBRARY(ROOTNTuple)
 #include <memory>
 #include <typeinfo>
 
-using REntry = ROOT::Experimental::REntry;
-using ROOT::Experimental::RNTupleFillStatus;
-using RNTupleModel = ROOT::Experimental::RNTupleModel;
-using RNTupleWriter = ROOT::Experimental::RNTupleWriter;
+using REntry = ROOT::REntry;
+using ROOT::RNTupleFillStatus;
+using RNTupleModel = ROOT::RNTupleModel;
+using RNTupleWriter = ROOT::RNTupleWriter;
 
 class FairEventHeader;
 class FairFileHeader;
@@ -97,7 +97,7 @@ class FairRNTupleSink : public FairSink
 
     bool fPersistentBranchesDone{false};   //!
 
-    std::vector<std::pair<REntry::RFieldToken, void*>> fTokenAddress;
+    std::vector<std::pair<ROOT::RFieldToken, void*>> fTokenAddress;
 
     ClassDefOverride(FairRNTupleSink, 1);
 };

--- a/fairroot/base/source/FairRNTupleSource.h
+++ b/fairroot/base/source/FairRNTupleSource.h
@@ -37,7 +37,7 @@ R__LOAD_LIBRARY(ROOTNTuple)
 #include <map>
 #include <memory>
 
-using RNTupleReader = ROOT::Experimental::RNTupleReader;
+using RNTupleReader = ROOT::RNTupleReader;
 
 class FairEventHeader;
 class FairFileHeader;


### PR DESCRIPTION
Just updating the namespaces for ROOT 6.36+.

Generally this branch seems to be working for SHiP, but I'll let you know if I discover any issues during testing and upstream any fixes we might make.